### PR TITLE
Add distance display and dynamic light

### DIFF
--- a/example1/app.js
+++ b/example1/app.js
@@ -16,7 +16,7 @@ const CONFIG = {
         timeStep: 0.05
     },
     lighting: {
-        position: [1.0, 1.0, 1.0, 0.0],
+        position: [1.0, 1.0, 1.0, 1.0],
         ambient: [0.2, 0.2, 0.2, 1.0],
         diffuse: [1.0, 1.0, 0.8, 1.0],
         specular: [1.0, 1.0, 1.0, 1.0]
@@ -56,6 +56,10 @@ class Character3DApp {
             this.cameraController.bindToCanvas(this.renderer.canvas, () => this.character.position);
 
             this.inputManager = new InputManager();
+
+            this.lightOffsets = { x: 0, y: 5, z: 0 };
+            this.totalDistance = 0;
+            this.lastZ = 0;
             
             // Create scene objects
             this.character = new Character3D(this.renderer, this.jointController);
@@ -65,6 +69,7 @@ class Character3DApp {
             // Initialize WebGL
             this.initWebGL();
             this.setupInput();
+            this.setupUI();
             this.start();
             
         } catch (error) {
@@ -121,6 +126,20 @@ class Character3DApp {
             }
         });
     }
+
+    setupUI() {
+        const bind = (id, axis) => {
+            const el = document.getElementById(id);
+            if (el) {
+                el.addEventListener('input', () => {
+                    this.lightOffsets[axis] = parseFloat(el.value);
+                });
+            }
+        };
+        bind('light-x', 'x');
+        bind('light-y', 'y');
+        bind('light-z', 'z');
+    }
     
     reset() {
         this.animationController.jumpTime = 0;
@@ -129,6 +148,11 @@ class Character3DApp {
 
         this.jointController.angles = { ...CONFIG.initialJointAngles };
         this.character.position = vec3(0, 0, -50);
+
+        this.totalDistance = 0;
+        this.lastZ = this.character.position[2];
+        const distElem = document.getElementById('distance');
+        if (distElem) distElem.textContent = this.totalDistance.toFixed(2);
 
         // GroundManager 초기화
         this.groundManager = new GroundManager(this.renderer);
@@ -159,10 +183,23 @@ class Character3DApp {
         this.character.setPosition(this.animationController.getCurrentPosition());
         this.character.setOrientation(this.animationController.getCurrentOrientation());
 
+        const charPos = this.character.position;
+        this.totalDistance += charPos[2] - this.lastZ;
+        this.lastZ = charPos[2];
+        const distElem = document.getElementById('distance');
+        if (distElem) distElem.textContent = this.totalDistance.toFixed(2);
+
+        const lightPos = vec4(
+            charPos[0] + this.lightOffsets.x,
+            charPos[1] + this.lightOffsets.y,
+            charPos[2] + this.lightOffsets.z,
+            1.0
+        );
+        this.renderer.updateLightPosition(lightPos);
+
         // GroundManager 업데이트: 개구리의 z위치를 넘겨줌
         this.groundManager.update(this.character.position[2]);
 
-        const charPos = this.character.position;
         const groundHeight = this.groundManager.getGroundHeightAt(charPos[0], charPos[2]);
 
         if (groundHeight !== null && charPos[1] <= groundHeight) {

--- a/example1/example1.html
+++ b/example1/example1.html
@@ -73,5 +73,17 @@ void main() {
 <canvas id="gl-canvas" width="1024" height="1024">
 Oops ... your browser doesn't support the HTML5 canvas element
 </canvas>
+<div id="ui">
+  <div id="distance">0</div>
+  <label>Light X
+    <input id="light-x" type="range" min="-10" max="10" step="0.1" value="0">
+  </label>
+  <label>Light Y
+    <input id="light-y" type="range" min="-10" max="10" step="0.1" value="5">
+  </label>
+  <label>Light Z
+    <input id="light-z" type="range" min="-10" max="10" step="0.1" value="0">
+  </label>
+</div>
 </body>
 </html>

--- a/example1/renderer.js
+++ b/example1/renderer.js
@@ -137,7 +137,11 @@ class WebGLRenderer {
     popMatrix() {
         return this.matrixStack.pop();
     }
-    
+
+    updateLightPosition(position) {
+        this.gl.uniform4fv(this.uniformLocations.lightPosition, flatten(position));
+    }
+
     clear() {
         this.gl.clear(this.gl.COLOR_BUFFER_BIT | this.gl.DEPTH_BUFFER_BIT);
     }


### PR DESCRIPTION
## Summary
- show traveled distance and light sliders in the example
- track distance and show it in HTML
- allow adjusting light offsets during runtime
- keep point light above the frog position

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6840086afca083288fa40a4bb9d88fec