### PR TITLE
Add landing transition animation

### DIFF
--- a/example1/app.js
+++ b/example1/app.js
@@ -212,11 +212,10 @@ class Character3DApp {
         const groundHeight = this.groundManager.getGroundHeightAt(charPos[0], charPos[2]);
 
         if (groundHeight !== null && charPos[1] <= groundHeight) {
-            // 착지
-            this.animationController.isJumping = false;
-            this.animationController.jumpTime = 0;
-            this.animationController.jumpOrigin = vec3(charPos[0], groundHeight, charPos[2]);
-            //this.jointController.angles = { ...CONFIG.initialJointAngles };
+            // 착지 - use landing state
+            this.animationController.startLanding([
+                charPos[0], groundHeight, charPos[2]
+            ]);
         } else if (charPos[1] < -10.0) {
             // 낙사
             alert("Game Over");


### PR DESCRIPTION
## Summary
- add `isLanding` state and timer to AnimationController
- interpolate joint angles during landing
- expose `startLanding` helper
- call landing transition from `app.js` when ground contact occurs

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68401f8f1754832881c6424277f89674