### PR TITLE
Add depth texture extension and initShadowMap

### DIFF
--- a/example1/app.js
+++ b/example1/app.js
@@ -95,6 +95,7 @@ class Character3DApp {
         this.renderer.initShaders();
         this.renderer.setupBuffers();
         this.renderer.setupLighting();
+        this.renderer.initShadowMap();
 
         // Texture Load
         const image = new Image();


### PR DESCRIPTION
## Summary
- initialize texture coordinates array in `renderer.js`
- add fields for shadow framebuffer and extension handles
- implement `initShadowMap` to request `WEBGL_depth_texture` extension and create a depth texture
- call `initShadowMap` from app initialization

## Testing
- `node --check example1/renderer.js`
- `node --check example1/app.js`


------
https://chatgpt.com/codex/tasks/task_e_684034b8a3688328b8e8b243730daed8